### PR TITLE
Fix board colored-coordinate generation bias

### DIFF
--- a/CryptoCross/src/cryptocross/Board.java
+++ b/CryptoCross/src/cryptocross/Board.java
@@ -213,13 +213,10 @@ public class Board implements BoardInterface {
 
         int result[] = new int[size];
         for (int i = 0; i < size; i++) {
-            Integer newNumber = 0;
-            if (i > 0) {
-                do {
-                    newNumber = random.nextInt(boardLength - 1);
-                } while (existInArray(newNumber, result));
-            }
-
+            Integer newNumber;
+            do {
+                newNumber = random.nextInt(boardLength);
+            } while (existInArray(newNumber, result, i));
             result[i] = newNumber;
         }
 
@@ -232,9 +229,9 @@ public class Board implements BoardInterface {
      * @param array the array to search in
      * @return true if the number exists in the array, false otherwise
      */
-    private Boolean existInArray(int number, int[] array) {
+    private Boolean existInArray(int number, int[] array, int usedLength) {
 
-        for (int i = 0; i < array.length; i++) {
+        for (int i = 0; i < usedLength; i++) {
             if (number == array[i]) {
                 return true;
             }

--- a/CryptoCross/test/cryptocross/BoardTest.java
+++ b/CryptoCross/test/cryptocross/BoardTest.java
@@ -3,6 +3,9 @@ package cryptocross;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.SecureRandom;
 
 /**
  * Unit tests for the Board class player help tools.
@@ -275,5 +278,30 @@ public class BoardTest {
         Letter[][] boardArray = defaultBoard.getBoardArray();
         assertEquals(5, boardArray.length, "Board should be 5x5");
         assertEquals(5, boardArray[0].length, "Board should be 5x5");
+    }
+
+    @Test
+    public void testRandomArrayGenUsesFullBoardIndexRange() throws Exception {
+        Board testBoard = new Board(5);
+
+        Field randomField = Board.class.getDeclaredField("random");
+        randomField.setAccessible(true);
+        randomField.set(testBoard, new SecureRandom() {
+            private int callCount = 0;
+
+            @Override
+            public int nextInt(int bound) {
+                int value = (bound - 1) - callCount;
+                callCount++;
+                return Math.max(value, 0);
+            }
+        });
+
+        Method randomArrayGen = Board.class.getDeclaredMethod("randomArrayGen", Integer.class);
+        randomArrayGen.setAccessible(true);
+        int[] generated = (int[]) randomArrayGen.invoke(testBoard, 3);
+
+        assertEquals(4, generated[0],
+            "First generated coordinate should be allowed to use boardLength-1");
     }
 }


### PR DESCRIPTION
Closes #26

## What changed
- Fixed `Board.randomArrayGen` to:
  - generate the first coordinate randomly (not hardcoded to `0`),
  - use the full index range (`0..boardLength-1`),
  - enforce uniqueness only across already-generated positions.
- Updated helper signature to check uniqueness over populated prefix only.
- Added deterministic regression test `testRandomArrayGenUsesFullBoardIndexRange` in `BoardTest`.

## Repro evidence
- Before fix: new test failed with `expected: <4> but was: <0>`.
- After fix: `BoardTest` passes.

## Local validation
- `ant compile-test && java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.BoardTest`
- `ant clean run-junit5-tests`
- `ant clean jar`

All commands passed locally.
