### PR TITLE
Throw on unknown characters in letter point assignment

### DIFF
--- a/CryptoCross/src/cryptocross/Letter.java
+++ b/CryptoCross/src/cryptocross/Letter.java
@@ -181,6 +181,8 @@ public abstract class Letter {
             int_points = 3;
         } else if (ch_letter == '?') {
             int_points = 1;
+        } else {
+            throw new UknownCharacterException();
         }
 
     }

--- a/CryptoCross/test/cryptocross/LetterTest.java
+++ b/CryptoCross/test/cryptocross/LetterTest.java
@@ -101,4 +101,12 @@ public class LetterTest {
         assertTrue(str.contains("Points: 1"), 
             "toString should contain the points in the 'Points: 1' format");
     }
+
+    @Test
+    public void testUnknownCharacterThrowsException() {
+        assertThrows(UknownCharacterException.class, () -> new WhiteLetter('A'),
+            "Unsupported non-Greek characters should throw UknownCharacterException");
+        assertThrows(UknownCharacterException.class, () -> new RedLetter('1'),
+            "Unsupported numeric characters should throw UknownCharacterException");
+    }
 }


### PR DESCRIPTION
Closes #27

## What changed
- Updated `Letter.assignPoints()` to throw `UknownCharacterException` when a character is outside supported Greek letters / wildcard (`?`).
- Added `testUnknownCharacterThrowsException` in `LetterTest` to verify fail-fast behavior for invalid non-Greek and numeric inputs.

## Repro evidence
- Before fix: new test failed because no exception was thrown.
- After fix: `LetterTest` passes.

## Local validation
- `ant compile-test && java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.LetterTest`
- `ant clean run-junit5-tests`
- `ant clean jar`

All commands passed locally.
