### PR TITLE
Disable unconditional board debug output

### DIFF
--- a/CryptoCross/src/cryptocross/Board.java
+++ b/CryptoCross/src/cryptocross/Board.java
@@ -16,6 +16,8 @@ import java.util.List;
  * and provides operations for board manipulation.
  */
 public class Board implements BoardInterface {
+    /** Enable board snapshot printing for debugging only */
+    private static final boolean DEBUG_BOARD_OUTPUT = false;
 
     /** The length (dimension) of the square board */
     private Integer boardLength;
@@ -134,9 +136,13 @@ public class Board implements BoardInterface {
         }
 
         /* We shuffle the board using Fisher-Yates algorithm. */
-        show();
+        if (DEBUG_BOARD_OUTPUT) {
+            show();
+        }
         shuffle(boardArray);
-        show();
+        if (DEBUG_BOARD_OUTPUT) {
+            show();
+        }
     }
 
     /**

--- a/CryptoCross/test/cryptocross/BoardTest.java
+++ b/CryptoCross/test/cryptocross/BoardTest.java
@@ -3,8 +3,11 @@ package cryptocross;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 
 /**
@@ -303,5 +306,21 @@ public class BoardTest {
 
         assertEquals(4, generated[0],
             "First generated coordinate should be allowed to use boardLength-1");
+    }
+
+    @Test
+    public void testBoardConstructorDoesNotPrintDebugOutputByDefault() throws Exception {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream outputCapture = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(outputCapture));
+            new Board(5);
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        String output = outputCapture.toString(StandardCharsets.UTF_8);
+        assertFalse(output.contains("------------------------"),
+            "Board constructor should not dump debug board snapshots by default");
     }
 }


### PR DESCRIPTION
## Summary
- gate `Board.generateBoard()` debug `show()` calls behind an internal flag disabled by default
- add regression test to ensure board construction does not print board snapshots by default

## Validation
- ant clean run-junit5-tests
- ant clean jar

Closes #31
