### PR TITLE
Fix WordPilot neighbor symmetry and add regression tests

### DIFF
--- a/CryptoCross/src/cryptocross/WordPilot.java
+++ b/CryptoCross/src/cryptocross/WordPilot.java
@@ -95,11 +95,8 @@ public class WordPilot {
      * @return true if the positions are adjacent neighbors, false otherwise
      */
     public Boolean isNeighbour(Integer xPosition, Integer yPosition, Integer xNew, Integer yNew) {
-        if ((xNew - xPosition == 0 || xNew - xPosition == 1) 
-                && (yNew - yPosition == 0 || yNew - yPosition == 1)) {
-            return true;
-        } else {
-            return false;
-        }
+        int xDiff = Math.abs(xNew - xPosition);
+        int yDiff = Math.abs(yNew - yPosition);
+        return xDiff <= 1 && yDiff <= 1 && (xDiff != 0 || yDiff != 0);
     }
 }

--- a/CryptoCross/test/cryptocross/WordPilotTest.java
+++ b/CryptoCross/test/cryptocross/WordPilotTest.java
@@ -1,0 +1,31 @@
+package cryptocross;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class WordPilotTest {
+    @Test
+    public void testIsNeighbourReturnsTrueForAllEightDirections() {
+        WordPilot pilot = new WordPilot(new Letter[0][0]);
+
+        assertTrue(pilot.isNeighbour(5, 5, 4, 4));
+        assertTrue(pilot.isNeighbour(5, 5, 5, 4));
+        assertTrue(pilot.isNeighbour(5, 5, 6, 4));
+        assertTrue(pilot.isNeighbour(5, 5, 4, 5));
+        assertTrue(pilot.isNeighbour(5, 5, 6, 5));
+        assertTrue(pilot.isNeighbour(5, 5, 4, 6));
+        assertTrue(pilot.isNeighbour(5, 5, 5, 6));
+        assertTrue(pilot.isNeighbour(5, 5, 6, 6));
+    }
+
+    @Test
+    public void testIsNeighbourReturnsFalseForSameCellAndDistantCells() {
+        WordPilot pilot = new WordPilot(new Letter[0][0]);
+
+        assertFalse(pilot.isNeighbour(5, 5, 5, 5));
+        assertFalse(pilot.isNeighbour(5, 5, 7, 5));
+        assertFalse(pilot.isNeighbour(5, 5, 5, 7));
+        assertFalse(pilot.isNeighbour(5, 5, 7, 7));
+    }
+}


### PR DESCRIPTION
## Summary
- fix `WordPilot.isNeighbour` to use symmetric absolute deltas
- explicitly exclude same-cell selection from neighbor matches
- add focused `WordPilotTest` coverage for all 8 directions and non-neighbor cases

## Repro and Evidence
- before fix: new `WordPilotTest` failed for left/up adjacency and same-cell behavior
- after fix: full suite passes

## Validation
- ant clean run-junit5-tests
- ant clean jar

Closes #32
