### PR TITLE
Stabilize dictionary normalization for combined Greek diacritics

### DIFF
--- a/CryptoCross/src/cryptocross/Dictionary.java
+++ b/CryptoCross/src/cryptocross/Dictionary.java
@@ -8,6 +8,7 @@ package cryptocross;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.security.SecureRandom;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Scanner;
 import java.util.logging.Level;
@@ -227,6 +228,10 @@ public class Dictionary {
         word = word.replaceAll("[Ώ]", "Ω");
         word = word.replaceAll("[Ϊ]", "Ι");
         word = word.replaceAll("[Ϋ]", "Υ");
+        // Normalize decomposed forms and strip any remaining combining diacritics.
+        word = Normalizer.normalize(word, Normalizer.Form.NFD);
+        word = word.replaceAll("\\p{M}", "");
+        word = Normalizer.normalize(word, Normalizer.Form.NFC);
         return word;
     }
 

--- a/CryptoCross/test/cryptocross/DictionaryTest.java
+++ b/CryptoCross/test/cryptocross/DictionaryTest.java
@@ -187,4 +187,28 @@ public class DictionaryTest {
             Files.deleteIfExists(tempDict);
         }
     }
+
+    @Test
+    public void testGreekCombinedDiacriticsAreNormalized() throws Exception {
+        Path tempDict = Files.createTempFile("cryptocross-combined-diacritics-dict", ".txt");
+        try {
+            Files.writeString(tempDict, "μαΐου\n", StandardCharsets.UTF_8);
+
+            Dictionary combinedDictionary = new Dictionary(tempDict.toString(), 5);
+            ArrayList<String> boardWords = combinedDictionary.getBoardWords();
+
+            assertFalse(boardWords.isEmpty(), "Board words should not be empty");
+            for (String word : boardWords) {
+                assertEquals("ΜΑΙΟΥ", word,
+                    "Combined Greek diacritics should be normalized to plain Greek vowels");
+                for (char c : word.toCharArray()) {
+                    assertTrue("ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ".contains(String.valueOf(c)),
+                        "Word should contain only plain Greek uppercase characters");
+                }
+            }
+            assertTrue(combinedDictionary.containsWord("ΜΑΙΟΥ"));
+        } finally {
+            Files.deleteIfExists(tempDict);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- normalize dictionary words by stripping Unicode combining marks after uppercase conversion
- keep existing Greek precomposed replacements and add robust fallback normalization
- add regression test for combined-diacritic input (`μαΐου`) to ensure output is plain Greek uppercase

## Repro and Evidence
- before fix: `DictionaryTest.testGreekCombinedDiacriticsAreNormalized` failed with `No dictionary words fit max size 5`
- before fix (stress): repeated `BoardTest` runs intermittently failed with `UknownCharacterException` in `Letter.assignPoints`
- after fix: targeted regression test passes, full suite passes, and `BoardTest` loop passed 30/30 iterations

## Validation
- ant clean run-junit5-tests
- ant clean jar
- ant compile-test
- 30x loop: `java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.BoardTest`

Closes #41
