### PR TITLE
Enforce adjacency in board word validation

### DIFF
--- a/CryptoCross/src/cryptocross/Board.java
+++ b/CryptoCross/src/cryptocross/Board.java
@@ -423,6 +423,23 @@ public class Board implements BoardInterface {
         if (word == null || word.isEmpty()) {
             return false;
         }
+
+        // Ensure all selected letters form a contiguous neighbor path.
+        WordPilot wordPilot = new WordPilot(boardArray);
+        for (int i = 1; i < word.size(); i++) {
+            Letter previous = word.get(i - 1);
+            Letter current = word.get(i);
+            if (previous == null || current == null) {
+                return false;
+            }
+            if (!wordPilot.isNeighbour(
+                    previous.getXcoord(),
+                    previous.getYcoord(),
+                    current.getXcoord(),
+                    current.getYcoord())) {
+                return false;
+            }
+        }
         
         // Build the word string from letters
         StringBuilder wordBuilder = new StringBuilder();

--- a/CryptoCross/test/cryptocross/BoardTest.java
+++ b/CryptoCross/test/cryptocross/BoardTest.java
@@ -8,7 +8,10 @@ import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 
 /**
  * Unit tests for the Board class player help tools.
@@ -322,5 +325,51 @@ public class BoardTest {
         String output = outputCapture.toString(StandardCharsets.UTF_8);
         assertFalse(output.contains("------------------------"),
             "Board constructor should not dump debug board snapshots by default");
+    }
+
+    @Test
+    public void testCheckWordValidityAcceptsAdjacentDictionaryWord() throws Exception {
+        Path tempDict = Files.createTempFile("cryptocross-adjacent-word", ".txt");
+        try {
+            Files.writeString(tempDict, "ΑΒ\n", StandardCharsets.UTF_8);
+            Board testBoard = new Board(5, tempDict.toString());
+
+            Letter letterA = new WhiteLetter('Α');
+            letterA.setCoords(0, 0);
+            Letter letterB = new WhiteLetter('Β');
+            letterB.setCoords(0, 1);
+
+            ArrayList<Letter> word = new ArrayList<>();
+            word.add(letterA);
+            word.add(letterB);
+
+            assertTrue(testBoard.checkWordValidity(word),
+                "Adjacent letters that form a dictionary word should be valid");
+        } finally {
+            Files.deleteIfExists(tempDict);
+        }
+    }
+
+    @Test
+    public void testCheckWordValidityRejectsNonAdjacentDictionaryWord() throws Exception {
+        Path tempDict = Files.createTempFile("cryptocross-nonadjacent-word", ".txt");
+        try {
+            Files.writeString(tempDict, "ΑΒ\n", StandardCharsets.UTF_8);
+            Board testBoard = new Board(5, tempDict.toString());
+
+            Letter letterA = new WhiteLetter('Α');
+            letterA.setCoords(0, 0);
+            Letter letterB = new WhiteLetter('Β');
+            letterB.setCoords(0, 2);
+
+            ArrayList<Letter> word = new ArrayList<>();
+            word.add(letterA);
+            word.add(letterB);
+
+            assertFalse(testBoard.checkWordValidity(word),
+                "Non-adjacent letters should be rejected even if they form a dictionary word");
+        } finally {
+            Files.deleteIfExists(tempDict);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enforce contiguous-neighbor validation in `Board.checkWordValidity`
- reject words when any consecutive pair of selected letters is non-adjacent
- add focused tests for adjacent-valid and non-adjacent-invalid dictionary words

## Repro and Evidence
- before fix: `BoardTest.testCheckWordValidityRejectsNonAdjacentDictionaryWord` failed (`expected false, was true`)
- after fix: Board targeted suite and full local suite pass

## Validation
- ant clean compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.BoardTest
- ant clean run-junit5-tests
- ant clean jar

Closes #38
