### PR TITLE
Prevent duplicate valid words from scoring twice

### DIFF
--- a/CryptoCross/src/cryptocross/CryptoCross.java
+++ b/CryptoCross/src/cryptocross/CryptoCross.java
@@ -906,6 +906,13 @@ public class CryptoCross extends JFrame implements ActionListener {
             
             // Check if word is valid
             if (gameBoard.checkWordValidity(currentWord)) {
+                String completedWord = buildWordString(currentWord);
+                if (!player.registerCompletedWord(completedWord)) {
+                    lb_foundAword.setText("↺ Η λέξη έχει ήδη βρεθεί!");
+                    clearCurrentWord();
+                    return;
+                }
+
                 // Calculate points
                 int wordPoints = calculateWordPoints(currentWord);
                 
@@ -1055,6 +1062,14 @@ public class CryptoCross extends JFrame implements ActionListener {
                 lb_foundAword.setText("Επιλέξτε δύο γράμματα για εναλλαγή");
             }
         }
+    }
+
+    private String buildWordString(ArrayList<Letter> word) {
+        StringBuilder wordBuilder = new StringBuilder();
+        for (Letter letter : word) {
+            wordBuilder.append(letter.getLetterChar());
+        }
+        return wordBuilder.toString();
     }
     
     private int calculateWordPoints(ArrayList<Letter> word) {

--- a/CryptoCross/src/cryptocross/Player.java
+++ b/CryptoCross/src/cryptocross/Player.java
@@ -5,6 +5,9 @@
  */
 package cryptocross;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Represents a player in the CryptoCross game.
  * Tracks the player's name, score, and number of words completed.
@@ -20,6 +23,9 @@ public class Player implements PlayerInterface {
     /** The number of words the player has completed */
     private Integer int_wordsCompleted;
 
+    /** Set of words already completed in the current game */
+    private Set<String> completedWords;
+
     /**
      * Constructs a new Player with initial values.
      * Score and words completed are initialized to 0.
@@ -27,6 +33,7 @@ public class Player implements PlayerInterface {
     public Player() {
         this.int_playerScore = 0;
         this.int_wordsCompleted = 0;
+        this.completedWords = new HashSet<>();
     }
 
     /**
@@ -89,6 +96,24 @@ public class Player implements PlayerInterface {
     @Override
     public void playerCompletedAWord() {
         this.int_wordsCompleted++;
+    }
+
+    /**
+     * Registers a completed word for the current game.
+     * @param word the completed word
+     * @return true if the word was new and registered, false if invalid or already completed
+     */
+    public boolean registerCompletedWord(String word) {
+        if (word == null) {
+            return false;
+        }
+
+        String normalizedWord = word.trim();
+        if (normalizedWord.isEmpty()) {
+            return false;
+        }
+
+        return completedWords.add(normalizedWord);
     }
 
 }

--- a/CryptoCross/test/cryptocross/PlayerTest.java
+++ b/CryptoCross/test/cryptocross/PlayerTest.java
@@ -72,4 +72,21 @@ public class PlayerTest {
         assertEquals(80, player.getPlayerScore(), 
             "Score should be updated correctly");
     }
+
+    @Test
+    public void testRegisterCompletedWordRejectsDuplicates() {
+        assertTrue(player.registerCompletedWord("ΑΒ"),
+            "First completed word submission should be accepted");
+        assertFalse(player.registerCompletedWord("ΑΒ"),
+            "Duplicate completed word submission should be rejected");
+        assertTrue(player.registerCompletedWord("ΓΔ"),
+            "Different completed words should still be accepted");
+    }
+
+    @Test
+    public void testRegisterCompletedWordRejectsInvalidInput() {
+        assertFalse(player.registerCompletedWord(null));
+        assertFalse(player.registerCompletedWord(""));
+        assertFalse(player.registerCompletedWord("   "));
+    }
 }


### PR DESCRIPTION
## Summary
- add player-level completed-word registry to reject duplicate submissions in a game
- wire `CryptoCross` scoring flow to skip score/word-count updates when the word is already completed
- add focused `PlayerTest` coverage for duplicate and invalid completed-word registration

## Repro and Evidence
- before fix: duplicate valid word submissions could be re-scored repeatedly
- after fix: duplicate submissions are rejected via `player.registerCompletedWord(...)` and scoring path is bypassed

## Validation
- ant clean compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.PlayerTest
- ant clean run-junit5-tests
- ant clean jar

Closes #39
