### PR TITLE
Extract word submission decisions into service

### DIFF
--- a/CryptoCross/src/cryptocross/WordSubmissionService.java
+++ b/CryptoCross/src/cryptocross/WordSubmissionService.java
@@ -1,0 +1,70 @@
+package cryptocross;
+
+import java.util.ArrayList;
+
+/**
+ * Encapsulates non-UI word submission decisions for the game flow.
+ */
+public class WordSubmissionService {
+    public enum SubmissionStatus {
+        EMPTY,
+        INVALID,
+        DUPLICATE,
+        ACCEPTED
+    }
+
+    public static class SubmissionResult {
+        private final SubmissionStatus status;
+        private final int points;
+
+        public SubmissionResult(SubmissionStatus status, int points) {
+            this.status = status;
+            this.points = points;
+        }
+
+        public SubmissionStatus getStatus() {
+            return status;
+        }
+
+        public int getPoints() {
+            return points;
+        }
+    }
+
+    public SubmissionResult evaluate(ArrayList<Letter> currentWord, Board gameBoard, Player player) {
+        if (currentWord == null || currentWord.isEmpty()) {
+            return new SubmissionResult(SubmissionStatus.EMPTY, 0);
+        }
+
+        if (gameBoard == null || player == null) {
+            return new SubmissionResult(SubmissionStatus.INVALID, 0);
+        }
+
+        if (!gameBoard.checkWordValidity(currentWord)) {
+            return new SubmissionResult(SubmissionStatus.INVALID, 0);
+        }
+
+        String completedWord = buildWordString(currentWord);
+        if (!player.registerCompletedWord(completedWord)) {
+            return new SubmissionResult(SubmissionStatus.DUPLICATE, 0);
+        }
+
+        return new SubmissionResult(SubmissionStatus.ACCEPTED, calculateWordPoints(currentWord));
+    }
+
+    private String buildWordString(ArrayList<Letter> word) {
+        StringBuilder wordBuilder = new StringBuilder();
+        for (Letter letter : word) {
+            wordBuilder.append(letter.getLetterChar());
+        }
+        return wordBuilder.toString();
+    }
+
+    private int calculateWordPoints(ArrayList<Letter> word) {
+        int points = 0;
+        for (Letter letter : word) {
+            points += letter.getPoints();
+        }
+        return points;
+    }
+}

--- a/CryptoCross/test/cryptocross/WordSubmissionServiceTest.java
+++ b/CryptoCross/test/cryptocross/WordSubmissionServiceTest.java
@@ -1,0 +1,77 @@
+package cryptocross;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class WordSubmissionServiceTest {
+    private ArrayList<Letter> buildWord(char first, int x1, int y1, char second, int x2, int y2)
+            throws UknownCharacterException {
+        ArrayList<Letter> word = new ArrayList<>();
+        Letter letter1 = new WhiteLetter(first);
+        letter1.setCoords(x1, y1);
+        Letter letter2 = new WhiteLetter(second);
+        letter2.setCoords(x2, y2);
+        word.add(letter1);
+        word.add(letter2);
+        return word;
+    }
+
+    @Test
+    public void testEvaluateReturnsEmptyForNoSelection() throws Exception {
+        WordSubmissionService service = new WordSubmissionService();
+        Board board = new Board(5, "custom-test-dictionary.txt");
+        Player player = new Player();
+
+        WordSubmissionService.SubmissionResult result =
+            service.evaluate(new ArrayList<>(), board, player);
+
+        assertEquals(WordSubmissionService.SubmissionStatus.EMPTY, result.getStatus());
+        assertEquals(0, result.getPoints());
+    }
+
+    @Test
+    public void testEvaluateReturnsInvalidForUnknownWord() throws Exception {
+        Path tempDict = Files.createTempFile("cryptocross-submission-invalid", ".txt");
+        try {
+            Files.writeString(tempDict, "ΑΒ\n", StandardCharsets.UTF_8);
+            WordSubmissionService service = new WordSubmissionService();
+            Board board = new Board(5, tempDict.toString());
+            Player player = new Player();
+            ArrayList<Letter> word = buildWord('Α', 0, 0, 'Γ', 0, 1);
+
+            WordSubmissionService.SubmissionResult result = service.evaluate(word, board, player);
+
+            assertEquals(WordSubmissionService.SubmissionStatus.INVALID, result.getStatus());
+            assertEquals(0, result.getPoints());
+        } finally {
+            Files.deleteIfExists(tempDict);
+        }
+    }
+
+    @Test
+    public void testEvaluateAcceptsThenRejectsDuplicateWord() throws Exception {
+        Path tempDict = Files.createTempFile("cryptocross-submission-duplicate", ".txt");
+        try {
+            Files.writeString(tempDict, "ΑΒ\n", StandardCharsets.UTF_8);
+            WordSubmissionService service = new WordSubmissionService();
+            Board board = new Board(5, tempDict.toString());
+            Player player = new Player();
+            ArrayList<Letter> word = buildWord('Α', 0, 0, 'Β', 0, 1);
+
+            WordSubmissionService.SubmissionResult first = service.evaluate(word, board, player);
+            WordSubmissionService.SubmissionResult second = service.evaluate(word, board, player);
+
+            assertEquals(WordSubmissionService.SubmissionStatus.ACCEPTED, first.getStatus());
+            assertTrue(first.getPoints() > 0);
+            assertEquals(WordSubmissionService.SubmissionStatus.DUPLICATE, second.getStatus());
+            assertEquals(0, second.getPoints());
+        } finally {
+            Files.deleteIfExists(tempDict);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordSubmissionService` to centralize non-UI submission decisions (empty/invalid/duplicate/accepted)
- refactor `CryptoCross` check-word flow to use service result status and points
- add focused `WordSubmissionServiceTest` coverage for empty, invalid, and duplicate paths

## Repro and Evidence
- before extraction: submission decisions were embedded in Swing handler logic
- after extraction: decision logic is testable in isolation and behavior remains consistent in UI flow

## Validation
- ant clean compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.WordSubmissionServiceTest
- ant clean run-junit5-tests
- ant clean jar

Closes #48
