### PR TITLE
Add immediate adjacency feedback during letter selection

### DIFF
--- a/CryptoCross/src/cryptocross/CryptoCross.java
+++ b/CryptoCross/src/cryptocross/CryptoCross.java
@@ -48,6 +48,8 @@ public class CryptoCross extends JFrame implements ActionListener {
     private WordPilot wordPilot;
     /** Service for non-UI word submission decisions */
     private WordSubmissionService wordSubmissionService;
+    /** Service for adjacency checks while selecting letters */
+    private WordSelectionService wordSelectionService;
     /** Maximum number of words the player is allowed to complete */
     private Integer int_maxAllowedWords;
     /** Target/goal number of points to be attained by the player */
@@ -163,6 +165,7 @@ public class CryptoCross extends JFrame implements ActionListener {
 
         currentWord = new ArrayList<>();
         wordSubmissionService = new WordSubmissionService();
+        wordSelectionService = new WordSelectionService();
 
         //Initialize Player
         initializePlayer();
@@ -653,6 +656,10 @@ public class CryptoCross extends JFrame implements ActionListener {
                             lb2_wordPoints.setText(Integer.toString(int_currentWordPoints));
                         } else {
                             // Select letter
+                            if (!wordSelectionService.canSelectNext(currentWord, tempLetter)) {
+                                lb_foundAword.setText("✗ Επιλέξτε γειτονικό γράμμα");
+                                return;
+                            }
                             ((JButton) e.getSource()).setBackground(Color.YELLOW);
                             currentWord.add(tempLetter);
                             

--- a/CryptoCross/src/cryptocross/WordSelectionService.java
+++ b/CryptoCross/src/cryptocross/WordSelectionService.java
@@ -1,0 +1,34 @@
+package cryptocross;
+
+import java.util.ArrayList;
+
+/**
+ * Encapsulates adjacency checks for incremental letter selection.
+ */
+public class WordSelectionService {
+    public boolean canSelectNext(ArrayList<Letter> currentWord, Letter candidate) {
+        if (candidate == null) {
+            return false;
+        }
+
+        if (currentWord == null || currentWord.isEmpty()) {
+            return true;
+        }
+
+        Letter previous = currentWord.get(currentWord.size() - 1);
+        if (previous == null
+                || previous.getXcoord() == null
+                || previous.getYcoord() == null
+                || candidate.getXcoord() == null
+                || candidate.getYcoord() == null) {
+            return false;
+        }
+
+        WordPilot wordPilot = new WordPilot(null);
+        return wordPilot.isNeighbour(
+                previous.getXcoord(),
+                previous.getYcoord(),
+                candidate.getXcoord(),
+                candidate.getYcoord());
+    }
+}

--- a/CryptoCross/test/cryptocross/WordSelectionServiceTest.java
+++ b/CryptoCross/test/cryptocross/WordSelectionServiceTest.java
@@ -1,0 +1,40 @@
+package cryptocross;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class WordSelectionServiceTest {
+    private Letter createLetter(char c, int x, int y) throws UknownCharacterException {
+        Letter letter = new WhiteLetter(c);
+        letter.setCoords(x, y);
+        return letter;
+    }
+
+    @Test
+    public void testCanSelectNextAllowsFirstSelection() throws Exception {
+        WordSelectionService service = new WordSelectionService();
+        ArrayList<Letter> currentWord = new ArrayList<>();
+
+        assertTrue(service.canSelectNext(currentWord, createLetter('Α', 3, 3)));
+    }
+
+    @Test
+    public void testCanSelectNextAllowsAdjacentSelection() throws Exception {
+        WordSelectionService service = new WordSelectionService();
+        ArrayList<Letter> currentWord = new ArrayList<>();
+        currentWord.add(createLetter('Α', 3, 3));
+
+        assertTrue(service.canSelectNext(currentWord, createLetter('Β', 4, 4)));
+    }
+
+    @Test
+    public void testCanSelectNextRejectsNonAdjacentSelection() throws Exception {
+        WordSelectionService service = new WordSelectionService();
+        ArrayList<Letter> currentWord = new ArrayList<>();
+        currentWord.add(createLetter('Α', 3, 3));
+
+        assertFalse(service.canSelectNext(currentWord, createLetter('Β', 3, 5)));
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordSelectionService` to decide whether a newly clicked letter can extend the current word
- integrate adjacency check into letter-selection flow before mutating `currentWord`
- show immediate status feedback (`✗ Επιλέξτε γειτονικό γράμμα`) when selection is non-adjacent
- add focused `WordSelectionServiceTest` coverage for first/adjacent/non-adjacent selections

## Repro and Evidence
- before fix: non-adjacent letters were accepted into `currentWord` and only rejected at submission time
- after fix: non-adjacent clicks are rejected immediately and no selection state is mutated

## Validation
- ant clean compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.WordSelectionServiceTest
- ant clean run-junit5-tests
- ant clean jar

Closes #49
