### PR TITLE
Reset help-action selection state after board mutations

### DIFF
--- a/CryptoCross/src/cryptocross/CryptoCross.java
+++ b/CryptoCross/src/cryptocross/CryptoCross.java
@@ -50,6 +50,8 @@ public class CryptoCross extends JFrame implements ActionListener {
     private WordSubmissionService wordSubmissionService;
     /** Service for adjacency checks while selecting letters */
     private WordSelectionService wordSelectionService;
+    /** Service for board-mutation help-action state updates */
+    private HelpActionStateService helpActionStateService;
     /** Maximum number of words the player is allowed to complete */
     private Integer int_maxAllowedWords;
     /** Target/goal number of points to be attained by the player */
@@ -166,6 +168,7 @@ public class CryptoCross extends JFrame implements ActionListener {
         currentWord = new ArrayList<>();
         wordSubmissionService = new WordSubmissionService();
         wordSelectionService = new WordSelectionService();
+        helpActionStateService = new HelpActionStateService();
 
         //Initialize Player
         initializePlayer();
@@ -629,12 +632,8 @@ public class CryptoCross extends JFrame implements ActionListener {
                                 // Update counters
                                 int_UsedSwapLetter++;
                                 checkHelps();
-                                
-                                // Exit swap mode
-                                tf_swapMode = false;
-                                swapLetter1 = null;
-                                swapLetter2 = null;
-                                
+
+                                applyHelpMutationStateReset();
                                 // Refresh the board
                                 refreshBoard();
                                 lb_foundAword.setText("Εναλλαγή ολοκληρώθηκε!");
@@ -976,6 +975,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                             gameBoard.deleteRow(row);
                             int_UsedDeleteRow++;
                             checkHelps();
+                            applyHelpMutationStateReset();
                             refreshBoard();
                         } else {
                             JOptionPane.showMessageDialog(thisFrame,
@@ -1006,6 +1006,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                             gameBoard.reorderRow(row);
                             int_UsedReorderRow++;
                             checkHelps();
+                            applyHelpMutationStateReset();
                             refreshBoard();
                         } else {
                             JOptionPane.showMessageDialog(thisFrame,
@@ -1036,6 +1037,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                             gameBoard.reorderColumn(column);
                             int_UsedReorderColumn++;
                             checkHelps();
+                            applyHelpMutationStateReset();
                             refreshBoard();
                         } else {
                             JOptionPane.showMessageDialog(thisFrame,
@@ -1057,6 +1059,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                 gameBoard.reorderBoard();
                 int_UsedReorderBoard++;
                 checkHelps();
+                applyHelpMutationStateReset();
                 refreshBoard();
             }
 
@@ -1077,6 +1080,16 @@ public class CryptoCross extends JFrame implements ActionListener {
             points += letter.getPoints();
         }
         return points;
+    }
+
+    private void applyHelpMutationStateReset() {
+        HelpActionStateService.HelpActionState state =
+                helpActionStateService.onBoardMutation(player.getPlayerScore(), tf_swapMode, currentWord);
+        tf_swapMode = state.isSwapMode();
+        swapLetter1 = null;
+        swapLetter2 = null;
+        int_currentWordPoints = state.getCurrentWordPoints();
+        lb2_wordPoints.setText(Integer.toString(int_currentWordPoints));
     }
     
     private void clearCurrentWord() {

--- a/CryptoCross/src/cryptocross/HelpActionStateService.java
+++ b/CryptoCross/src/cryptocross/HelpActionStateService.java
@@ -1,0 +1,39 @@
+package cryptocross;
+
+import java.util.ArrayList;
+
+/**
+ * Encapsulates state updates after board-mutating help actions.
+ */
+public class HelpActionStateService {
+    public static class HelpActionState {
+        private final int totalScore;
+        private final int currentWordPoints;
+        private final boolean swapMode;
+
+        public HelpActionState(int totalScore, int currentWordPoints, boolean swapMode) {
+            this.totalScore = totalScore;
+            this.currentWordPoints = currentWordPoints;
+            this.swapMode = swapMode;
+        }
+
+        public int getTotalScore() {
+            return totalScore;
+        }
+
+        public int getCurrentWordPoints() {
+            return currentWordPoints;
+        }
+
+        public boolean isSwapMode() {
+            return swapMode;
+        }
+    }
+
+    public HelpActionState onBoardMutation(int totalScore, boolean swapMode, ArrayList<Letter> currentWord) {
+        if (currentWord != null) {
+            currentWord.clear();
+        }
+        return new HelpActionState(totalScore, 0, false);
+    }
+}

--- a/CryptoCross/test/cryptocross/HelpActionStateServiceTest.java
+++ b/CryptoCross/test/cryptocross/HelpActionStateServiceTest.java
@@ -1,0 +1,41 @@
+package cryptocross;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class HelpActionStateServiceTest {
+    private Letter createLetter(char c, int x, int y) throws UknownCharacterException {
+        Letter letter = new WhiteLetter(c);
+        letter.setCoords(x, y);
+        return letter;
+    }
+
+    @Test
+    public void testOnBoardMutationResetsCurrentWordStateForRowOperationContext() throws Exception {
+        HelpActionStateService service = new HelpActionStateService();
+        ArrayList<Letter> currentWord = new ArrayList<>();
+        currentWord.add(createLetter('Α', 0, 0));
+        currentWord.add(createLetter('Β', 0, 1));
+
+        HelpActionStateService.HelpActionState state = service.onBoardMutation(42, false, currentWord);
+
+        assertEquals(42, state.getTotalScore());
+        assertEquals(0, state.getCurrentWordPoints());
+        assertFalse(state.isSwapMode());
+        assertEquals(0, currentWord.size(), "Selected letters should be cleared after board mutation");
+    }
+
+    @Test
+    public void testOnBoardMutationDisablesSwapModeForSwapOperationContext() {
+        HelpActionStateService service = new HelpActionStateService();
+        ArrayList<Letter> currentWord = new ArrayList<>();
+
+        HelpActionStateService.HelpActionState state = service.onBoardMutation(17, true, currentWord);
+
+        assertEquals(17, state.getTotalScore());
+        assertEquals(0, state.getCurrentWordPoints());
+        assertFalse(state.isSwapMode(), "Swap mode should be disabled after board mutation");
+    }
+}


### PR DESCRIPTION
## Summary
- add `HelpActionStateService` to centralize board-mutation help-action state updates
- wire help-action mutation paths (delete/reorder row, reorder column, reorder board, swap completion) to reset current-word state consistently
- add focused `HelpActionStateServiceTest` coverage for row-operation and swap-operation contexts

## Repro and Evidence
- before fix: board-mutating help actions could leave stale `currentWord`/word-points state
- after fix: mutation paths clear selected letters, reset current-word points to 0, and disable swap mode

## Validation
- ant clean compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.HelpActionStateServiceTest
- ant clean run-junit5-tests
- ant clean jar

Closes #50
