### PR TITLE
test: deterministic board fixture support

### DIFF
--- a/CryptoCross/src/cryptocross/Board.java
+++ b/CryptoCross/src/cryptocross/Board.java
@@ -74,6 +74,44 @@ public class Board implements BoardInterface {
     }
 
     /**
+     * Constructs a board from a deterministic fixture for tests.
+     * Package-private on purpose so production code keeps using generated boards.
+     * @param boardLength the length (dimension) of the square board
+     * @param dictionaryPath the path to the dictionary file to use
+     * @param boardFixture the exact board layout to apply
+     * @throws UknownCharacterException if dictionary setup encounters an unknown character
+     */
+    Board(Integer boardLength, String dictionaryPath, Letter[][] boardFixture) throws UknownCharacterException {
+        this.boardLength = boardLength;
+        boardArray = new Letter[boardLength][boardLength];
+        random = new SecureRandom();
+        dict = new Dictionary(dictionaryPath, boardLength);
+        wordsNum = 0;
+
+        applyBoardFixture(boardFixture);
+    }
+
+    private void applyBoardFixture(Letter[][] boardFixture) {
+        if (boardFixture == null || boardFixture.length != boardLength) {
+            throw new IllegalArgumentException("Board fixture must match board length");
+        }
+
+        for (int i = 0; i < boardLength; i++) {
+            if (boardFixture[i] == null || boardFixture[i].length != boardLength) {
+                throw new IllegalArgumentException("Board fixture must be square with board length dimensions");
+            }
+            for (int j = 0; j < boardLength; j++) {
+                Letter letter = boardFixture[i][j];
+                if (letter == null) {
+                    throw new IllegalArgumentException("Board fixture cannot contain null letters");
+                }
+                letter.setCoords(i, j);
+                boardArray[i][j] = letter;
+            }
+        }
+    }
+
+    /**
      * Generates a new board layout based on board length.
      * Determines the number of colored letters based on board size,
      * places dictionary words, fills remaining spaces with random characters,

--- a/CryptoCross/test/cryptocross/BoardTest.java
+++ b/CryptoCross/test/cryptocross/BoardTest.java
@@ -287,6 +287,42 @@ public class BoardTest {
     }
 
     @Test
+    public void testFixtureConstructorBuildsDeterministicBoard() throws Exception {
+        char[][] fixtureChars = {
+            {'Α', 'Β', 'Γ', 'Δ', 'Ε'},
+            {'Ζ', 'Η', 'Θ', 'Ι', 'Κ'},
+            {'Λ', 'Μ', 'Ν', 'Ξ', 'Ο'},
+            {'Π', 'Ρ', 'Σ', 'Τ', 'Υ'},
+            {'Φ', 'Χ', 'Ψ', 'Ω', 'Α'}
+        };
+
+        Board fixtureBoard = new Board(5, "custom-test-dictionary.txt", createFixture(fixtureChars));
+        Letter[][] boardArray = fixtureBoard.getBoardArray();
+
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                assertEquals(fixtureChars[i][j], boardArray[i][j].getLetterChar(),
+                    "Fixture letter should be preserved at [" + i + "][" + j + "]");
+                assertEquals(i, boardArray[i][j].getXcoord(),
+                    "X coordinate should match deterministic fixture position");
+                assertEquals(j, boardArray[i][j].getYcoord(),
+                    "Y coordinate should match deterministic fixture position");
+            }
+        }
+    }
+
+    @Test
+    public void testFixtureConstructorRejectsInvalidFixture() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new Board(5, "custom-test-dictionary.txt", new Letter[4][5]),
+            "Fixture with incorrect dimensions should be rejected");
+
+        assertThrows(IllegalArgumentException.class,
+            () -> new Board(5, "custom-test-dictionary.txt", new Letter[5][5]),
+            "Fixture with null letters should be rejected");
+    }
+
+    @Test
     public void testRandomArrayGenUsesFullBoardIndexRange() throws Exception {
         Board testBoard = new Board(5);
 
@@ -371,5 +407,15 @@ public class BoardTest {
         } finally {
             Files.deleteIfExists(tempDict);
         }
+    }
+
+    private Letter[][] createFixture(char[][] chars) throws UknownCharacterException {
+        Letter[][] fixture = new Letter[chars.length][chars[0].length];
+        for (int i = 0; i < chars.length; i++) {
+            for (int j = 0; j < chars[i].length; j++) {
+                fixture[i][j] = new WhiteLetter(chars[i][j]);
+            }
+        }
+        return fixture;
     }
 }


### PR DESCRIPTION
## Summary
- add a package-private Board constructor that accepts a deterministic Letter[][] fixture for tests
- validate fixture dimensions/null entries and normalize coordinates when loading fixture cells
- add BoardTest coverage for deterministic fixture loading and invalid fixture rejection

Closes #56

## Validation
- ant compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.BoardTest
- ant clean run-junit5-tests
- ant clean jar
