### PR TITLE
i18n: localize gameplay status strings

### DIFF
--- a/CryptoCross/src/cryptocross/CryptoCross.java
+++ b/CryptoCross/src/cryptocross/CryptoCross.java
@@ -621,7 +621,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                                 // First letter selected
                                 swapLetter1 = tempLetter;
                                 ((JButton) e.getSource()).setBackground(Color.CYAN);
-                                lb_foundAword.setText("Επιλέξτε το δεύτερο γράμμα");
+                                lb_foundAword.setText(messages.getString("status.swap.select.second"));
                             } else if (swapLetter2 == null && tempLetter != swapLetter1) {
                                 // Second letter selected
                                 swapLetter2 = tempLetter;
@@ -636,14 +636,14 @@ public class CryptoCross extends JFrame implements ActionListener {
                                 applyHelpMutationStateReset();
                                 // Refresh the board
                                 refreshBoard();
-                                lb_foundAword.setText("Εναλλαγή ολοκληρώθηκε!");
+                                lb_foundAword.setText(messages.getString("status.swap.completed"));
                             } else if (tempLetter == swapLetter1) {
                                 // Cancel swap mode if clicking the same letter
                                 tf_swapMode = false;
                                 swapLetter1 = null;
                                 swapLetter2 = null;
                                 refreshBoard();
-                                lb_foundAword.setText("Εναλλαγή ακυρώθηκε");
+                                lb_foundAword.setText(messages.getString("status.swap.cancelled"));
                             }
                         } else if (((JButton) e.getSource()).getBackground().equals(Color.YELLOW)) {
                             // Deselect letter
@@ -656,7 +656,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                         } else {
                             // Select letter
                             if (!wordSelectionService.canSelectNext(currentWord, tempLetter)) {
-                                lb_foundAword.setText("✗ Επιλέξτε γειτονικό γράμμα");
+                                lb_foundAword.setText(messages.getString("status.select.neighbor"));
                                 return;
                             }
                             ((JButton) e.getSource()).setBackground(Color.YELLOW);
@@ -780,7 +780,7 @@ public class CryptoCross extends JFrame implements ActionListener {
         
         if (choice == JOptionPane.YES_OPTION) {
             disableGameControls();
-            lb_foundAword.setText("Το παιχνίδι ακυρώθηκε");
+            lb_foundAword.setText(messages.getString("status.game.cancelled"));
             JOptionPane.showMessageDialog(thisFrame,
                     "Το παιχνίδι τερματίστηκε.\nΒαθμολογία: " + player.getPlayerScore(),
                     "Παιχνίδι Τερματίστηκε",
@@ -926,7 +926,8 @@ public class CryptoCross extends JFrame implements ActionListener {
                 // Update UI
                 lb2_totalPoints.setText(Integer.toString(player.getPlayerScore()));
                 lb2_wordsFound.setText(player.getCompletedWordsNum() + "/" + int_maxAllowedWords);
-                lb_foundAword.setText("✓ Σωστή λέξη! +" + wordPoints + " πόντοι");
+                lb_foundAword.setText(MessageFormat.format(
+                        messages.getString("status.word.accepted"), wordPoints));
                 
                 clearCurrentWord();
                 
@@ -953,11 +954,11 @@ public class CryptoCross extends JFrame implements ActionListener {
                     disableGameControls();
                 }
             } else if (submissionResult.getStatus() == WordSubmissionService.SubmissionStatus.DUPLICATE) {
-                lb_foundAword.setText("↺ Η λέξη έχει ήδη βρεθεί!");
+                lb_foundAword.setText(messages.getString("status.word.duplicate"));
                 clearCurrentWord();
             } else {
                 // Invalid word
-                lb_foundAword.setText("✗ Λανθασμένη λέξη!");
+                lb_foundAword.setText(messages.getString("status.word.invalid"));
                 clearCurrentWord();
             }
 
@@ -1069,7 +1070,7 @@ public class CryptoCross extends JFrame implements ActionListener {
                 tf_swapMode = true;
                 swapLetter1 = null;
                 swapLetter2 = null;
-                lb_foundAword.setText("Επιλέξτε δύο γράμματα για εναλλαγή");
+                lb_foundAword.setText(messages.getString("status.swap.select.two"));
             }
         }
     }

--- a/CryptoCross/src/cryptocross/CryptoCrossMessages.properties
+++ b/CryptoCross/src/cryptocross/CryptoCrossMessages.properties
@@ -84,3 +84,14 @@ help.main.html=<html><body style='width: 500px; padding: 10px;'>\
 </ul>\
 \
 </body></html>
+
+# Gameplay status labels
+status.swap.select.second=Επιλέξτε το δεύτερο γράμμα
+status.swap.completed=Εναλλαγή ολοκληρώθηκε!
+status.swap.cancelled=Εναλλαγή ακυρώθηκε
+status.select.neighbor=✗ Επιλέξτε γειτονικό γράμμα
+status.game.cancelled=Το παιχνίδι ακυρώθηκε
+status.word.accepted=✓ Σωστή λέξη! +{0} πόντοι
+status.word.duplicate=↺ Η λέξη έχει ήδη βρεθεί!
+status.word.invalid=✗ Λανθασμένη λέξη!
+status.swap.select.two=Επιλέξτε δύο γράμματα για εναλλαγή

--- a/CryptoCross/test/cryptocross/ResourceBundleTest.java
+++ b/CryptoCross/test/cryptocross/ResourceBundleTest.java
@@ -75,4 +75,36 @@ public class ResourceBundleTest {
         assertTrue(formatted.contains("3"), "Should contain formatted numbers");
         assertFalse(formatted.contains("{0}"), "Should not contain unformatted placeholders");
     }
+
+    @Test
+    public void testGameplayStatusKeysExist() {
+        ResourceBundle messages = ResourceBundle.getBundle("cryptocross.CryptoCrossMessages");
+        String[] requiredKeys = {
+            "status.swap.select.second",
+            "status.swap.completed",
+            "status.swap.cancelled",
+            "status.select.neighbor",
+            "status.game.cancelled",
+            "status.word.accepted",
+            "status.word.duplicate",
+            "status.word.invalid",
+            "status.swap.select.two"
+        };
+
+        for (String key : requiredKeys) {
+            String value = messages.getString(key);
+            assertNotNull(value, "Missing status key: " + key);
+            assertFalse(value.isEmpty(), "Status key should not be empty: " + key);
+        }
+    }
+
+    @Test
+    public void testAcceptedWordStatusFormatting() {
+        ResourceBundle messages = ResourceBundle.getBundle("cryptocross.CryptoCrossMessages");
+        String template = messages.getString("status.word.accepted");
+        String formatted = MessageFormat.format(template, 12);
+
+        assertTrue(formatted.contains("12"), "Accepted status should include formatted points");
+        assertFalse(formatted.contains("{0}"), "Accepted status should not contain raw placeholders");
+    }
 }


### PR DESCRIPTION
## Summary
- move gameplay status label text from hardcoded literals in CryptoCross.java into CryptoCrossMessages.properties
- use MessageFormat for the accepted-word status that includes dynamic points
- add ResourceBundleTest coverage for required gameplay status keys and accepted-word status formatting

Closes #57

## Validation
- ant compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.ResourceBundleTest --select-class cryptocross.HtmlMessageIntegrationTest --select-class cryptocross.MenuItemTest
- ant clean run-junit5-tests
- ant clean jar
