### PR TITLE
feat: add strict mode toggle for deselection

### DIFF
--- a/CryptoCross/src/cryptocross/CryptoCross.java
+++ b/CryptoCross/src/cryptocross/CryptoCross.java
@@ -647,6 +647,10 @@ public class CryptoCross extends JFrame implements ActionListener {
                             }
                         } else if (((JButton) e.getSource()).getBackground().equals(Color.YELLOW)) {
                             // Deselect letter
+                            if (!wordSelectionService.canDeselect(currentWord, tempLetter)) {
+                                lb_foundAword.setText(messages.getString("status.select.strict.deselect.last"));
+                                return;
+                            }
                             ((JButton) e.getSource()).setBackground(tempColor);
                             currentWord.remove(tempLetter);
                             
@@ -1081,6 +1085,10 @@ public class CryptoCross extends JFrame implements ActionListener {
             points += letter.getPoints();
         }
         return points;
+    }
+
+    void setStrictSelectionMode(boolean strictSelectionMode) {
+        wordSelectionService.setStrictSelectionMode(strictSelectionMode);
     }
 
     private void applyHelpMutationStateReset() {

--- a/CryptoCross/src/cryptocross/CryptoCrossMessages.properties
+++ b/CryptoCross/src/cryptocross/CryptoCrossMessages.properties
@@ -90,6 +90,7 @@ status.swap.select.second=Επιλέξτε το δεύτερο γράμμα
 status.swap.completed=Εναλλαγή ολοκληρώθηκε!
 status.swap.cancelled=Εναλλαγή ακυρώθηκε
 status.select.neighbor=✗ Επιλέξτε γειτονικό γράμμα
+status.select.strict.deselect.last=✗ Στην αυστηρή λειτουργία αποεπιλέγεται μόνο το τελευταίο γράμμα
 status.game.cancelled=Το παιχνίδι ακυρώθηκε
 status.word.accepted=✓ Σωστή λέξη! +{0} πόντοι
 status.word.duplicate=↺ Η λέξη έχει ήδη βρεθεί!

--- a/CryptoCross/src/cryptocross/WordSelectionService.java
+++ b/CryptoCross/src/cryptocross/WordSelectionService.java
@@ -6,6 +6,20 @@ import java.util.ArrayList;
  * Encapsulates adjacency checks for incremental letter selection.
  */
 public class WordSelectionService {
+    private boolean strictSelectionMode;
+
+    public WordSelectionService() {
+        this(false);
+    }
+
+    public WordSelectionService(boolean strictSelectionMode) {
+        this.strictSelectionMode = strictSelectionMode;
+    }
+
+    public void setStrictSelectionMode(boolean strictSelectionMode) {
+        this.strictSelectionMode = strictSelectionMode;
+    }
+
     public boolean canSelectNext(ArrayList<Letter> currentWord, Letter candidate) {
         if (candidate == null) {
             return false;
@@ -30,5 +44,22 @@ public class WordSelectionService {
                 previous.getYcoord(),
                 candidate.getXcoord(),
                 candidate.getYcoord());
+    }
+
+    public boolean canDeselect(ArrayList<Letter> currentWord, Letter candidate) {
+        if (candidate == null) {
+            return false;
+        }
+
+        if (currentWord == null || currentWord.isEmpty()) {
+            return true;
+        }
+
+        if (!strictSelectionMode) {
+            return true;
+        }
+
+        Letter lastSelected = currentWord.get(currentWord.size() - 1);
+        return candidate == lastSelected;
     }
 }

--- a/CryptoCross/test/cryptocross/ResourceBundleTest.java
+++ b/CryptoCross/test/cryptocross/ResourceBundleTest.java
@@ -84,6 +84,7 @@ public class ResourceBundleTest {
             "status.swap.completed",
             "status.swap.cancelled",
             "status.select.neighbor",
+            "status.select.strict.deselect.last",
             "status.game.cancelled",
             "status.word.accepted",
             "status.word.duplicate",

--- a/CryptoCross/test/cryptocross/WordSelectionServiceTest.java
+++ b/CryptoCross/test/cryptocross/WordSelectionServiceTest.java
@@ -37,4 +37,45 @@ public class WordSelectionServiceTest {
 
         assertFalse(service.canSelectNext(currentWord, createLetter('Β', 3, 5)));
     }
+
+    @Test
+    public void testCanDeselectAllowsAnySelectedLetterWhenStrictModeDisabled() throws Exception {
+        WordSelectionService service = new WordSelectionService();
+        ArrayList<Letter> currentWord = new ArrayList<>();
+        Letter first = createLetter('Α', 0, 0);
+        Letter second = createLetter('Β', 0, 1);
+        Letter third = createLetter('Γ', 0, 2);
+        currentWord.add(first);
+        currentWord.add(second);
+        currentWord.add(third);
+
+        assertTrue(service.canDeselect(currentWord, second));
+    }
+
+    @Test
+    public void testCanDeselectRejectsNonTerminalWhenStrictModeEnabled() throws Exception {
+        WordSelectionService service = new WordSelectionService(true);
+        ArrayList<Letter> currentWord = new ArrayList<>();
+        Letter first = createLetter('Α', 0, 0);
+        Letter second = createLetter('Β', 0, 1);
+        Letter third = createLetter('Γ', 0, 2);
+        currentWord.add(first);
+        currentWord.add(second);
+        currentWord.add(third);
+
+        assertFalse(service.canDeselect(currentWord, second));
+    }
+
+    @Test
+    public void testCanDeselectAllowsOnlyLastLetterWhenStrictModeEnabled() throws Exception {
+        WordSelectionService service = new WordSelectionService();
+        service.setStrictSelectionMode(true);
+        ArrayList<Letter> currentWord = new ArrayList<>();
+        Letter first = createLetter('Α', 0, 0);
+        Letter second = createLetter('Β', 0, 1);
+        currentWord.add(first);
+        currentWord.add(second);
+
+        assertTrue(service.canDeselect(currentWord, second));
+    }
 }


### PR DESCRIPTION
## Summary
- add strict selection mode support in WordSelectionService with default mode unchanged (strict disabled)
- gate deselection in CryptoCross through WordSelectionService and show a localized strict-mode status hint when blocked
- add tests for strict/non-strict deselection behavior and include new status key in resource-bundle checks

Closes #66

## Validation
- ant compile-test
- java -jar lib/junit-platform-console-standalone-1.10.1.jar --class-path build/classes:build/test/classes --select-class cryptocross.WordSelectionServiceTest --select-class cryptocross.ResourceBundleTest --select-class cryptocross.HtmlMessageIntegrationTest --select-class cryptocross.MenuItemTest
- ant clean run-junit5-tests
- ant clean jar
