### PR TITLE
docs: create roadmap v19 (#167)

### DIFF
--- a/docs/roadmap_changelog.md
+++ b/docs/roadmap_changelog.md
@@ -3,6 +3,18 @@
 Chronological record of merged roadmap issues.
 Add new entries at the top using `docs/roadmap_changelog_template.md`.
 
+## 2026-02-16 - #167 - Create roadmap_v19 after v18 completion
+- PR: #171
+- Summary:
+  - marked all v18 priorities complete in `docs/roadmap_v18.md`
+  - added `docs/roadmap_v19.md` with priorities `#168`, `#169`, and `#170`
+  - updated `docs/roadmap_index.md` to set v18 completed and v19 active, and added `docs/roadmap_v19.md` to file list
+- Validation:
+  - ./scripts/check_roadmap_links.sh
+  - ant clean run-junit5-tests
+  - ant clean jar
+- Risk/Notes: roadmap state accuracy depends on keeping issue numbering and status transitions synchronized each cycle
+
 ## 2026-02-16 - #162 - Add integration coverage for dictionary path persistence boundary
 - PR: #166
 - Summary:

--- a/docs/roadmap_index.md
+++ b/docs/roadmap_index.md
@@ -21,7 +21,8 @@ Quick navigation for roadmap versions and completion state.
 | v15 | 2026-02-16 | Completed | Manual-only workflow checker, release packaging checklist, gameplay backlog snapshot |
 | v16 | 2026-02-16 | Completed | Operations-index link checker, smoke evidence template, dictionary-size validation fix |
 | v17 | 2026-02-16 | Completed | Pre-merge checks script, naming conventions runbook, non-default dictionary-switch coverage |
-| v18 | 2026-02-16 | Active | PR title lint script, workflow-trigger checklist, dictionary-persistence boundary coverage |
+| v18 | 2026-02-16 | Completed | PR title lint script, workflow-trigger checklist, dictionary-persistence boundary coverage |
+| v19 | 2026-02-16 | Active | Active-roadmap issue guard, branch naming checker, invalid dictionary-switch coverage |
 
 ## Files
 - `docs/roadmap_v1.md`
@@ -42,6 +43,7 @@ Quick navigation for roadmap versions and completion state.
 - `docs/roadmap_v16.md`
 - `docs/roadmap_v17.md`
 - `docs/roadmap_v18.md`
+- `docs/roadmap_v19.md`
 
 ## Usage
 - Update this index when a new roadmap version is created.

--- a/docs/roadmap_v18.md
+++ b/docs/roadmap_v18.md
@@ -10,9 +10,9 @@
 - Validation baseline remains green locally (`ant clean run-junit5-tests`, `ant clean jar`).
 
 ## v18 Priorities
-- [ ] #159 Add PR title format lint script.
-- [ ] #161 Add manual workflow trigger decision checklist.
-- [ ] #162 Add integration coverage for dictionary path persistence boundary.
+- [x] #159 Add PR title format lint script.
+- [x] #161 Add manual workflow trigger decision checklist.
+- [x] #162 Add integration coverage for dictionary path persistence boundary.
 
 ## v18 Success Criteria
 - A PR title lint script validates issue-linked title format and is documented for local usage.

--- a/docs/roadmap_v19.md
+++ b/docs/roadmap_v19.md
@@ -1,0 +1,29 @@
+# CryptoCross Roadmap v19
+
+## Date
+- 2026-02-16
+
+## v18 Completion Summary
+- `#159` completed: added PR title format lint script and README usage.
+- `#161` completed: added manual workflow trigger decision checklist and operations-index link.
+- `#162` completed: added dictionary path persistence boundary integration coverage.
+- Validation baseline remains green locally (`ant clean run-junit5-tests`, `ant clean jar`).
+
+## v19 Priorities
+- [ ] #168 Add active-roadmap issue status guard script.
+- [ ] #169 Add branch naming convention checker script.
+- [ ] #170 Add integration coverage for invalid dictionary switch handling.
+
+## v19 Success Criteria
+- A guard script validates active roadmap issue references and reports issue states reliably.
+- A local branch naming checker validates issue-linked branch conventions before PR creation.
+- Integration coverage exists for invalid dictionary switch handling boundaries without UI refactors.
+- Each item follows repo workflow:
+  - one issue -> one branch -> one PR
+  - full local validations before merge
+  - final review before merge to `master`
+
+## Next Candidate Ideas (Post-v19)
+- Add a local guard to verify PR body and title checks in one command.
+- Add focused integration coverage for workflow runbook decision checklist references.
+- Add a script to summarize active-roadmap completion progress by issue state.


### PR DESCRIPTION
## Summary
- mark all v18 priorities complete in `docs/roadmap_v18.md`
- add new `docs/roadmap_v19.md` with priorities #168, #169, and #170
- update `docs/roadmap_index.md` (v18 completed, v19 active) and file list

## Validation
- ./scripts/check_roadmap_links.sh
- ant clean run-junit5-tests
- ant clean jar

## Roadmap
- Closes #167
